### PR TITLE
Max Size for logs in API and db-worker

### DIFF
--- a/api/logger.js
+++ b/api/logger.js
@@ -22,6 +22,9 @@ if (process.env.LOGGLY_TOKEN) {
   transports.push(transport);
 } else {
   transport = new winston.transports.File({
+    maxsize: 100 * 1024, // 10 MB
+    maxFiles: 3,
+    tailable: true,
     filename: `${logDir}/results.log`,
     timestamp: tsFormat
   });

--- a/db-worker/logger.js
+++ b/db-worker/logger.js
@@ -22,6 +22,9 @@ if (process.env.LOGGLY_TOKEN) {
   transports.push(transport);
 } else if (process.env.NODE_ENV == 'production') {
   transport = new winston.transports.File({
+    maxsize: 100 * 1024, // 10 MB
+    maxFiles: 3,
+    tailable: true,
     filename: `${logDir}/results.log`,
     timestamp: tsFormat
   });


### PR DESCRIPTION
Stop logs in API & db-worker from growing too large (one of them made it to 8GB on our instance!)