### PR TITLE
Update Node installation from v14 to v20

### DIFF
--- a/docs-gitbook/getting-started/installing-pushkin-and-dependencies/ubuntu-install.md
+++ b/docs-gitbook/getting-started/installing-pushkin-and-dependencies/ubuntu-install.md
@@ -33,8 +33,8 @@ $ sudo apt install curl
 To install the latest version of Node.js , follow [these instructions at NodeSource](https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions). They are copied below for your convenience, but you should follow the link in case their instructions have changed.
 
 ```bash
-$ curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-$ sudo apt install -y nodejs
+$ curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - &&\
+$ sudo apt-get install -y nodejs
 ```
 
 ![](../../.gitbook/assets/ubuntu2%20%281%29.gif)

--- a/docs-gitbook/getting-started/installing-pushkin-and-dependencies/ubuntu-install.md
+++ b/docs-gitbook/getting-started/installing-pushkin-and-dependencies/ubuntu-install.md
@@ -30,11 +30,23 @@ $ sudo apt install curl
 
 ### Install Node.js
 
-To install the latest version of Node.js , follow [these instructions at NodeSource](https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions). They are copied below for your convenience, but you should follow the link in case their instructions have changed.
+To install Node.js, first run the following command to install nvm:
 
 ```bash
-$ curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - &&\
-$ sudo apt-get install -y nodejs
+$ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+```
+
+Then use nvm to install Node.js:
+
+```bash
+$ nvm install 20.2.0
+```
+
+In case the preferred version of Node.js is changed, use the following commands to update:
+
+```bash
+$ nvm install <node_version>
+$ nvm use <node_version>
 ```
 
 ![](../../.gitbook/assets/ubuntu2%20%281%29.gif)


### PR DESCRIPTION
Node v14 is outdated and was giving me trouble building the site during a recent Pushkin upgrade. I have changed it to [v20](https://github.com/nodesource/distributions/blob/master/README.md#installation-instructions), which is the latest version so far.