### PR TITLE
add major bump to pushkin-cli

### DIFF
--- a/.changeset/famous-toes-speak.md
+++ b/.changeset/famous-toes-speak.md
@@ -1,4 +1,5 @@
 ---
+"pushkin-cli": major
 "@pushkin-templates/exp-basic": major
 ---
 


### PR DESCRIPTION
pushkin-cli was mistakenly left out of the changeset related to template packages. This will make sure the changelog is correctly generated.