### PR TITLE
Add modes to `rm exp` to pause/unpause data collection

### DIFF
--- a/.changeset/curly-walls-think.md
+++ b/.changeset/curly-walls-think.md
@@ -1,0 +1,6 @@
+---
+"pushkin-cli": patch
+---
+
+- Fixed issue where workers for experiments including capital letters would not be deleted by `rm exp --mode delete`.
+- Fixed issue where it was possible to create two experiments which would yield workers with the same name.

--- a/.changeset/tame-waves-hide.md
+++ b/.changeset/tame-waves-hide.md
@@ -1,0 +1,9 @@
+---
+"@pushkin-templates/exp-basic": minor
+"@pushkin-templates/exp-grammaticality-judgment": minor
+"@pushkin-templates/exp-lexical-decision": minor
+"@pushkin-templates/exp-self-paced-reading": minor
+"pushkin-cli": minor
+---
+
+Added modes to `rm exp` to pause and unpause data collection for the specified experiment(s).

--- a/docs/packages/pushkin-cli.md
+++ b/docs/packages/pushkin-cli.md
@@ -108,15 +108,16 @@ The command also integrates a new experiment into the Pushkin framework. It perf
 
 ### remove experiment
 
-This command allows users to remove an experiment from their site and offers two removal modes:
+This command allows users to remove an experiment from their site and offers three removal modes:
 
 1. **delete:** Deleting an experiment permanently removes all of its files, data, and associated Docker components. This command should only be used if you want the experiment completely gone, as it is irreversible. Note that this mode currently runs [`kill`](#kill), and will consequently delete **all** experiments' data from your local database, not just the experiment(s) you deleted. Future development may address this limitation.
 2. **archive:** Archiving an experiment removes it from your site's front end, so it is no longer accessible to participants. However, all of the experiment's files remain in place and the site's back end and data will not be affected.
+3. **pause-data:** Pausing data collection means that the front end of the experiment stays accessible, but no data from subsequent runs of that experiment will be saved to the Pushkin database. When data collection is paused, an additional trial is added to the beginning of the experiment informing potential participants that no data will be collected.
 
-The command has a third mode, `unarchive`, that adds archived experiments back to your site's front end.
+The `archive` and `pause-data` modes have complementary modes `unarchive` and `unpause-data` which respectively restore an archived experiment to the front end and resume data collection. The `delete` mode has no such complement, since it is permanent.
 
 !!! note
-    You must run [`prep`](#prep) after `remove experiment` for changes to your site to take effect.
+    You must run [`prep`](#prep) after `remove experiment` for the changes to your site to take effect.
 
 **Syntax:**
 
@@ -134,7 +135,7 @@ pushkin rm exp <options>
 
 - experiments: `-e` or `--experiments` allows you to specify which experiment(s) to delete, archive, or unarchive. Provide the experiments' short names (i.e. the name of the folder in the `/experiments` directory) separated by spaces after the `-e` flag (e.g. `pushkin rm exp -e exp1 exp2 exp3`). If the `--experiments` option is omitted, the CLI will interactively prompt you to select the experiments you want.
 
-- mode: `-m` or `--mode` allows you to specify the `delete`, `archive`, or `unarchive` mode (e.g. `pushkin rm exp -m delete`). If the `--mode` option is omitted, the CLI will interactively prompt you to select which mode you want.
+- mode: `-m` or `--mode` allows you to specify the `delete`, `archive`, `unarchive`, `pause-data`, or `unpause-data` mode (e.g. `pushkin rm exp -m delete`). If the `--mode` option is omitted, the CLI will interactively prompt you to select which mode you want.
 
 - force: `-f` or `--force` applies only to the `delete` mode and allows you to suppress the deletion confirmation prompt.
 
@@ -144,7 +145,7 @@ pushkin rm exp <options>
 
 **Details:**
 
-Archiving and unarchiving experiments is a simple operation that entails setting the `archived` property in the experiment's `config.yaml` file to `true` or `false`. You can change this property manually if you wish, but using `pushkin rm exp -m archive` offers a convenient way to quickly change this property for multiple experiments.
+All that results from calling `remove experiment` in the `archive` or `pause-data` mode (as well as their opposite modes) is that the experiment's `config.yaml` file will be updated with respect to the boolean property `archived` or `dataPaused`. You can change this property manually if you wish, but using `pushkin rm exp -m archive` or `pushkin rm exp -m pause-data` offers a convenient way to quickly change this property for multiple experiments.
 
 ### updateDB
 

--- a/packages/pushkin-cli/src/commands/setupdb/index.js
+++ b/packages/pushkin-cli/src/commands/setupdb/index.js
@@ -27,7 +27,7 @@ const fixConfig = function(configPath, verbose) {
     config.productionDB = "Main";
     try {
       temp = fs.writeFileSync(configPath, jsYaml.safeDump(config), 'utf8');
-      if (verbose) console.log(`Updated users/config.yaml to be compatible with default site template v2+.`);
+      if (verbose) console.log(`Updated "productionDB" in users/config.yaml`);
     } catch(e) {
       throw e;
     }

--- a/templates/experiments/basic/src/web page/src/index.js
+++ b/templates/experiments/basic/src/web page/src/index.js
@@ -3,6 +3,7 @@ import pushkinClient from 'pushkin-client';
 import { initJsPsych } from 'jspsych';
 import { connect } from 'react-redux';
 import { createTimeline } from './experiment';
+import jsPsychHtmlKeyboardResponse from '@jspsych/plugin-html-keyboard-response';
 import jsYaml from 'js-yaml';
 const fs = require('fs');
 
@@ -34,17 +35,39 @@ class quizComponent extends React.Component {
     this.setState({ experimentStarted: true });
 
     await pushkin.connect(this.props.api);
-    await pushkin.prepExperimentRun(this.props.userID);
+
+    // If data collection for the experiment is paused, make sure their userID doesn't get saved
+    if (expConfig.dataPaused) {
+      console.log("Data collection for this experiment is currently paused. No data will be saved.");
+    } else {
+      await pushkin.prepExperimentRun(this.props.userID);
+    }
 
     const jsPsych = initJsPsych({
       display_element: document.getElementById('jsPsychTarget'),
       on_finish: this.endExperiment.bind(this),
-      on_data_update: (data) => pushkin.saveStimulusResponse(data),
+      on_data_update: (data) => {
+        // Only call saveStimulusResponse if data collection is not paused
+        if (!expConfig.dataPaused) {
+          pushkin.saveStimulusResponse(data);
+        }
+      }
     });
 
     jsPsych.data.addProperties({user_id: this.props.userID}); //See https://www.jspsych.org/core_library/jspsych-data/#jspsychdataaddproperties
     
     const timeline = createTimeline(jsPsych);
+
+    // If data collection for the experiment is paused, insert a confirmation trial notifying the participant
+    if (expConfig.dataPaused) {
+      const dataPausedTrial = {
+        type: jsPsychHtmlKeyboardResponse,
+        stimulus: `<p>Data collection for this experiment is currently paused.</p>
+          <p>You can still view the experiment, but your data will <strong>not</strong> be saved.</p>
+          <p>Press any key to continue.</p>`
+      }
+      timeline.unshift(dataPausedTrial);
+    }
 
     jsPsych.run(timeline);
 
@@ -53,9 +76,15 @@ class quizComponent extends React.Component {
   }
 
   async endExperiment() {
-    document.getElementById("jsPsychTarget").innerHTML = "Processing...";
-    await pushkin.tabulateAndPostResults(this.props.userID, expConfig.experimentName)
-    document.getElementById("jsPsychTarget").innerHTML = "Thank you for participating!";
+    // If data collection is paused, add an ending note and don't save their completion to the users table
+    if (expConfig.dataPaused) {
+      document.getElementById("jsPsychTarget").innerHTML = `<p>Thank you for your interest in this experiment!</p>
+        <p>Data collection is currently paused. No data were saved.</p>`;
+    } else {
+      document.getElementById("jsPsychTarget").innerHTML = "<p>Processing...</p>";
+      await pushkin.tabulateAndPostResults(this.props.userID, expConfig.experimentName);
+      document.getElementById("jsPsychTarget").innerHTML = "<p>Thank you for participating!</p>";
+    }
   }
 
   render() {

--- a/templates/experiments/grammaticality-judgment/src/web page/src/index.js
+++ b/templates/experiments/grammaticality-judgment/src/web page/src/index.js
@@ -3,13 +3,16 @@ import pushkinClient from 'pushkin-client';
 import { initJsPsych } from 'jspsych';
 import { connect } from 'react-redux';
 import { createTimeline } from './experiment';
+import jsPsychHtmlKeyboardResponse from '@jspsych/plugin-html-keyboard-response';
 import jsYaml from 'js-yaml';
 const fs = require('fs');
 
 //stylin'
 import './assets/experiment.css';
-const experimentConfig = require('./config').default;
-
+// These are aesthetic settings for the experiment from config.js
+const expAesthetics = require('./config').default;
+// These are the config settings for the overall Pushkin experiment
+// from the config.yaml at the top level of the experiment
 const expConfig = jsYaml.load(fs.readFileSync('../config.yaml'), 'utf8');
 
 const pushkin = new pushkinClient();
@@ -35,34 +38,62 @@ class quizComponent extends React.Component {
     this.setState({ experimentStarted: true });
 
     await pushkin.connect(this.props.api);
-    await pushkin.prepExperimentRun(this.props.userID);
+
+    // If data collection for the experiment is paused, make sure their userID doesn't get saved
+    if (expConfig.dataPaused) {
+      console.log("Data collection for this experiment is currently paused. No data will be saved.");
+    } else {
+      await pushkin.prepExperimentRun(this.props.userID);
+    }
 
     const jsPsych = initJsPsych({
       display_element: document.getElementById('jsPsychTarget'),
       on_finish: this.endExperiment.bind(this),
-      on_data_update: (data) => pushkin.saveStimulusResponse(data),
+      on_data_update: (data) => {
+        // Only call saveStimulusResponse if data collection is not paused
+        if (!expConfig.dataPaused) {
+          pushkin.saveStimulusResponse(data);
+        }
+      }
     });
 
     jsPsych.data.addProperties({user_id: this.props.userID}); //See https://www.jspsych.org/core_library/jspsych-data/#jspsychdataaddproperties
     
     const timeline = createTimeline(jsPsych);
 
+    // If data collection for the experiment is paused, insert a confirmation trial notifying the participant
+    if (expConfig.dataPaused) {
+      const dataPausedTrial = {
+        type: jsPsychHtmlKeyboardResponse,
+        stimulus: `<p>Data collection for this experiment is currently paused.</p>
+          <p>You can still view the experiment, but your data will <strong>not</strong> be saved.</p>
+          <p>Press any key to continue.</p>`
+      }
+      timeline.unshift(dataPausedTrial);
+    }
+
     jsPsych.run(timeline);
 
     document.getElementById('jsPsychTarget').focus();
-    
-    // Settings from config file
-    document.getElementById('jsPsychTarget').style.color = experimentConfig.fontColor;
-    document.getElementById('jsPsychTarget').style.fontSize = experimentConfig.fontSize;
-    document.getElementById('jsPsychTarget').style.fontFamily = experimentConfig.fontFamily;
+
+    // Settings from config.js
+    document.getElementById('jsPsychTarget').style.color = expAesthetics.fontColor;
+    document.getElementById('jsPsychTarget').style.fontSize = expAesthetics.fontSize;
+    document.getElementById('jsPsychTarget').style.fontFamily = expAesthetics.fontFamily;
 
     this.setState({ loading: false });
   }
 
   async endExperiment() {
-    document.getElementById("jsPsychTarget").innerHTML = "Processing...";
-    await pushkin.tabulateAndPostResults(this.props.userID, expConfig.experimentName)
-    document.getElementById("jsPsychTarget").innerHTML = "Thank you for participating!";
+    // If data collection is paused, add an ending note and don't save their completion to the users table
+    if (expConfig.dataPaused) {
+      document.getElementById("jsPsychTarget").innerHTML = `<p>Thank you for your interest in this experiment!</p>
+        <p>Data collection is currently paused. No data were saved.</p>`;
+    } else {
+      document.getElementById("jsPsychTarget").innerHTML = "<p>Processing...</p>";
+      await pushkin.tabulateAndPostResults(this.props.userID, expConfig.experimentName);
+      document.getElementById("jsPsychTarget").innerHTML = "<p>Thank you for participating!</p>";
+    }
   }
 
   render() {

--- a/templates/experiments/lexical-decision/src/web page/src/index.js
+++ b/templates/experiments/lexical-decision/src/web page/src/index.js
@@ -3,13 +3,16 @@ import pushkinClient from 'pushkin-client';
 import { initJsPsych } from 'jspsych';
 import { connect } from 'react-redux';
 import { createTimeline } from './experiment';
+import jsPsychHtmlKeyboardResponse from '@jspsych/plugin-html-keyboard-response';
 import jsYaml from 'js-yaml';
 const fs = require('fs');
 
 //stylin'
 import './assets/experiment.css';
-import experimentConfig from './config';
-
+// These are aesthetic settings for the experiment from config.js
+const expAesthetics = require('./config').default;
+// These are the config settings for the overall Pushkin experiment
+// from the config.yaml at the top level of the experiment
 const expConfig = jsYaml.load(fs.readFileSync('../config.yaml'), 'utf8');
 
 const pushkin = new pushkinClient();
@@ -35,34 +38,62 @@ class quizComponent extends React.Component {
     this.setState({ experimentStarted: true });
 
     await pushkin.connect(this.props.api);
-    await pushkin.prepExperimentRun(this.props.userID);
+
+    // If data collection for the experiment is paused, make sure their userID doesn't get saved
+    if (expConfig.dataPaused) {
+      console.log("Data collection for this experiment is currently paused. No data will be saved.");
+    } else {
+      await pushkin.prepExperimentRun(this.props.userID);
+    }
 
     const jsPsych = initJsPsych({
       display_element: document.getElementById('jsPsychTarget'),
       on_finish: this.endExperiment.bind(this),
-      on_data_update: (data) => pushkin.saveStimulusResponse(data),
+      on_data_update: (data) => {
+        // Only call saveStimulusResponse if data collection is not paused
+        if (!expConfig.dataPaused) {
+          pushkin.saveStimulusResponse(data);
+        }
+      }
     });
 
     jsPsych.data.addProperties({user_id: this.props.userID}); //See https://www.jspsych.org/core_library/jspsych-data/#jspsychdataaddproperties
     
     const timeline = createTimeline(jsPsych);
 
+    // If data collection for the experiment is paused, insert a confirmation trial notifying the participant
+    if (expConfig.dataPaused) {
+      const dataPausedTrial = {
+        type: jsPsychHtmlKeyboardResponse,
+        stimulus: `<p>Data collection for this experiment is currently paused.</p>
+          <p>You can still view the experiment, but your data will <strong>not</strong> be saved.</p>
+          <p>Press any key to continue.</p>`
+      }
+      timeline.unshift(dataPausedTrial);
+    }
+
     jsPsych.run(timeline);
 
     document.getElementById('jsPsychTarget').focus();
-    
-    // Settings from config file
-    document.getElementById('jsPsychTarget').style.color = experimentConfig.fontColor;
-    document.getElementById('jsPsychTarget').style.fontSize = experimentConfig.fontSize;
-    document.getElementById('jsPsychTarget').style.fontFamily = experimentConfig.fontFamily;
-    
+
+    // Settings from config.js
+    document.getElementById('jsPsychTarget').style.color = expAesthetics.fontColor;
+    document.getElementById('jsPsychTarget').style.fontSize = expAesthetics.fontSize;
+    document.getElementById('jsPsychTarget').style.fontFamily = expAesthetics.fontFamily;
+
     this.setState({ loading: false });
   }
 
   async endExperiment() {
-    document.getElementById("jsPsychTarget").innerHTML = "Processing...";
-    await pushkin.tabulateAndPostResults(this.props.userID, expConfig.experimentName)
-    document.getElementById("jsPsychTarget").innerHTML = "Thank you for participating!";
+    // If data collection is paused, add an ending note and don't save their completion to the users table
+    if (expConfig.dataPaused) {
+      document.getElementById("jsPsychTarget").innerHTML = `<p>Thank you for your interest in this experiment!</p>
+        <p>Data collection is currently paused. No data were saved.</p>`;
+    } else {
+      document.getElementById("jsPsychTarget").innerHTML = "<p>Processing...</p>";
+      await pushkin.tabulateAndPostResults(this.props.userID, expConfig.experimentName);
+      document.getElementById("jsPsychTarget").innerHTML = "<p>Thank you for participating!</p>";
+    }
   }
 
   render() {

--- a/templates/experiments/self-paced-reading/src/web page/src/index.js
+++ b/templates/experiments/self-paced-reading/src/web page/src/index.js
@@ -3,13 +3,16 @@ import pushkinClient from 'pushkin-client';
 import { initJsPsych } from 'jspsych';
 import { connect } from 'react-redux';
 import { createTimeline } from './experiment';
+import jsPsychHtmlKeyboardResponse from '@jspsych/plugin-html-keyboard-response';
 import jsYaml from 'js-yaml';
 const fs = require('fs');
 
 //stylin'
 import './assets/experiment.css';
-import experimentConfig from './config';
-
+// These are aesthetic settings for the experiment from config.js
+const expAesthetics = require('./config').default;
+// These are the config settings for the overall Pushkin experiment
+// from the config.yaml at the top level of the experiment
 const expConfig = jsYaml.load(fs.readFileSync('../config.yaml'), 'utf8');
 
 const pushkin = new pushkinClient();
@@ -35,34 +38,62 @@ class quizComponent extends React.Component {
     this.setState({ experimentStarted: true });
 
     await pushkin.connect(this.props.api);
-    await pushkin.prepExperimentRun(this.props.userID);
+
+    // If data collection for the experiment is paused, make sure their userID doesn't get saved
+    if (expConfig.dataPaused) {
+      console.log("Data collection for this experiment is currently paused. No data will be saved.");
+    } else {
+      await pushkin.prepExperimentRun(this.props.userID);
+    }
 
     const jsPsych = initJsPsych({
       display_element: document.getElementById('jsPsychTarget'),
       on_finish: this.endExperiment.bind(this),
-      on_data_update: (data) => pushkin.saveStimulusResponse(data),
+      on_data_update: (data) => {
+        // Only call saveStimulusResponse if data collection is not paused
+        if (!expConfig.dataPaused) {
+          pushkin.saveStimulusResponse(data);
+        }
+      }
     });
 
     jsPsych.data.addProperties({user_id: this.props.userID}); //See https://www.jspsych.org/core_library/jspsych-data/#jspsychdataaddproperties
     
     const timeline = createTimeline(jsPsych);
 
+    // If data collection for the experiment is paused, insert a confirmation trial notifying the participant
+    if (expConfig.dataPaused) {
+      const dataPausedTrial = {
+        type: jsPsychHtmlKeyboardResponse,
+        stimulus: `<p>Data collection for this experiment is currently paused.</p>
+          <p>You can still view the experiment, but your data will <strong>not</strong> be saved.</p>
+          <p>Press any key to continue.</p>`
+      }
+      timeline.unshift(dataPausedTrial);
+    }
+
     jsPsych.run(timeline);
 
     document.getElementById('jsPsychTarget').focus();
-    
-    // Settings from config file
-    document.getElementById('jsPsychTarget').style.color = experimentConfig.fontColor;
-    document.getElementById('jsPsychTarget').style.fontSize = experimentConfig.fontSize;
-    document.getElementById('jsPsychTarget').style.fontFamily = experimentConfig.fontFamily;
+
+    // Settings from config.js
+    document.getElementById('jsPsychTarget').style.color = expAesthetics.fontColor;
+    document.getElementById('jsPsychTarget').style.fontSize = expAesthetics.fontSize;
+    document.getElementById('jsPsychTarget').style.fontFamily = expAesthetics.fontFamily;
 
     this.setState({ loading: false });
   }
 
   async endExperiment() {
-    document.getElementById("jsPsychTarget").innerHTML = "Processing...";
-    await pushkin.tabulateAndPostResults(this.props.userID, expConfig.experimentName)
-    document.getElementById("jsPsychTarget").innerHTML = "Thank you for participating!";
+    // If data collection is paused, add an ending note and don't save their completion to the users table
+    if (expConfig.dataPaused) {
+      document.getElementById("jsPsychTarget").innerHTML = `<p>Thank you for your interest in this experiment!</p>
+        <p>Data collection is currently paused. No data were saved.</p>`;
+    } else {
+      document.getElementById("jsPsychTarget").innerHTML = "<p>Processing...</p>";
+      await pushkin.tabulateAndPostResults(this.props.userID, expConfig.experimentName);
+      document.getElementById("jsPsychTarget").innerHTML = "<p>Thank you for participating!</p>";
+    }
   }
 
   render() {


### PR DESCRIPTION
Users can now pause and unpause data collection for specific experiments using `remove experiment` (or `rm exp`). Like with the other modes for `rm exp`, you can specify (un)pause in the command like `pushkin rm exp --mode pause-data`. No data will be logged from a paused experiment (not just for the experiment's `_stimulusResponse` table but also the `users` and `userResults` tables). There are notes inserted before and after a paused experiment informing potential participants that data collection is paused.

I tested this by adding one experiment from each template, first checking that they work and log data, then pausing them and checking that they don't log data, then finally unpausing them and checking that data were again being logged.

NB: when testing this, you'll need to install exp templates from path, since the changes are in both the CLI and the exp templates.